### PR TITLE
Feat/force path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ Playwire's react component library
   cssClass="leaderboard"
 />
 ```
+
+- publisherId [required] -The publisher’s unique identifier.
+
+- id [required] - The website’s unique identifier.
+
+- forcePath [optional] - Override the URL path. When this prop changes, it will reload OOP/tagless units based on the config rules for the new path.
+
+- type [required] - The tagged ad units that the AM sets up. These units require a placeholder, for example, leaderboard, medium rectangle, and skyscraper.
+
+- cssClass [optional] - Places css class on div element. Won’t load any styles.

--- a/components/Ramp.js
+++ b/components/Ramp.js
@@ -98,9 +98,7 @@ class Ramp extends _react.default.Component {
       // {type: 'inimg'},
       // {type: 'skin'}
       ]).finally(() => {
-        return window.ramp.displayUnits();
-      }).finally(() => {
-        console.log('done');
+        window.ramp.displayUnits();
       });
     });
   }

--- a/components/Ramp.js
+++ b/components/Ramp.js
@@ -5,6 +5,14 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
+require("core-js/modules/es.promise.js");
+
+require("core-js/modules/web.dom-collections.iterator.js");
+
+require("core-js/modules/es.array.includes.js");
+
+require("core-js/modules/es.promise.finally.js");
+
 var _react = _interopRequireDefault(require("react"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -13,7 +21,25 @@ window.ramp = window.ramp || {};
 window.ramp.que = window.ramp.que || [];
 window.ramp.passiveMode = true;
 window._pwRampComponentLoaded = window._pwRampComponentLoaded || false;
-const oopUnits = ['trendi_slideshow', 'trendi_video', 'site_skin', 'flex_leaderboard', 'top_rail', 'right_rail', 'bottom_rail', 'left_rail'];
+const oopUnits = ['trendi_slideshow', 'trendi_video', 'site_skin', 'flex_leaderboard', 'top_rail', 'right_rail', 'bottom_rail', 'left_rail']; // destroy the units when componenent unmounts
+
+const cleanUp = parentId => new Promise((resolve, reject) => {
+  // possible that component was removed before first ad was created
+  if (!window.ramp.settings || !window.ramp.settings.slots) return;
+  delete window.ramp.forcePath;
+  let slotsToRemove = [];
+  Object.entries(window.ramp.settings.slots).forEach(_ref => {
+    let [slotName, slot] = _ref;
+
+    if (oopUnits.includes(slot.type) || slot.videoType === 'Bolt Player') {
+      slotsToRemove.push(slotName);
+    }
+  });
+
+  if (slotsToRemove.length > 0) {
+    window.ramp.destroyUnits(slotsToRemove).finally(() => resolve());
+  }
+});
 
 class Ramp extends _react.default.Component {
   constructor(props) {
@@ -24,17 +50,30 @@ class Ramp extends _react.default.Component {
       return;
     }
 
-    this.init(props.publisherId, props.id);
+    this.init(props);
   }
 
-  init(publisherId, id) {
-    if (window._pwRampComponentLoaded) return;
-    window._pwRampComponentLoaded = true;
-    window.ramp.config = "https://config.playwire.com/".concat(publisherId, "/v2/websites/").concat(id, "/banner.json");
-    const configScript = document.createElement("script"); // configScript.src = `https://cdn.intergient.com/${publisherId}/${id}/ramp.js`;
+  init(_ref2) {
+    let {
+      publisherId,
+      id,
+      forcePath
+    } = _ref2;
+    if (forcePath) window.ramp.forcePath = forcePath; // make sure we only do this once per "app" load
 
-    configScript.src = 'https://cdn.intergient.com/ramp_core.js';
-    document.head.appendChild(configScript);
+    if (!window._pwRampComponentLoaded) {
+      window._pwRampComponentLoaded = true;
+      window.ramp.config = "https://config.playwire.com/".concat(publisherId, "/v2/websites/").concat(id, "/banner.json");
+      const configScript = document.createElement("script"); // configScript.src = `https://cdn.intergient.com/${publisherId}/${id}/ramp.js`;
+
+      configScript.src = 'https://cdn.intergient.com/ramp_core.js';
+      document.head.appendChild(configScript);
+    }
+
+    this.displayTaglessUnits();
+  }
+
+  displayTaglessUnits() {
     window.ramp.que.push(() => {
       window.ramp.addUnits([{
         type: 'trendi_slideshow'
@@ -58,9 +97,30 @@ class Ramp extends _react.default.Component {
       // {type: 'in_content'},
       // {type: 'inimg'},
       // {type: 'skin'}
-      ]).then(() => {
-        window.ramp.displayUnits();
+      ]).finally(() => {
+        return window.ramp.displayUnits();
+      }).finally(() => {
+        console.log('done');
       });
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.forcePath && prevProps.forcePath !== this.props.forcePath) {
+      window.ramp.forcePath = this.props.forcePath;
+      window.ramp.que.push(() => {
+        window.ramp.setPath(this.props.forcePath).then(() => {
+          return cleanUp();
+        }).then(() => {
+          this.displayTaglessUnits();
+        });
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    window.ramp.que.push(() => {
+      cleanUp(this.unitToAdd.selectorId);
     });
   }
 

--- a/components/RampUnit.js
+++ b/components/RampUnit.js
@@ -65,7 +65,7 @@ const cleanUp = parentId => {
   }
 };
 
-class Ramp extends _react.default.Component {
+class RampUnit extends _react.default.Component {
   constructor(props) {
     super(props);
     this.rendered = false;
@@ -99,4 +99,4 @@ class Ramp extends _react.default.Component {
 
 }
 
-exports.default = Ramp;
+exports.default = RampUnit;

--- a/components/RampUnit.js
+++ b/components/RampUnit.js
@@ -50,7 +50,7 @@ const getInitialUnit = props => {
 
 const cleanUp = parentId => {
   // possible that component was removed before first ad was created
-  if (!window.ramp.setttings || !window.ramp.settings.slots) return;
+  if (!window.ramp.settings || !window.ramp.settings.slots) return;
   let slotToRemove = null;
   Object.entries(window.ramp.settings.slots).forEach(_ref => {
     let [slotName, slot] = _ref;

--- a/src/lib/components/Ramp.js
+++ b/src/lib/components/Ramp.js
@@ -94,10 +94,7 @@ export default class Ramp extends React.Component {
                 // {type: 'skin'}
             ])
             .finally(() => {
-                return window.ramp.displayUnits();
-            })
-            .finally(() => {
-                console.log('done')
+                window.ramp.displayUnits();
             });
         });
     }

--- a/src/lib/components/Ramp.js
+++ b/src/lib/components/Ramp.js
@@ -16,6 +16,32 @@ const oopUnits = [
     'left_rail'
 ];
 
+// destroy the units when componenent unmounts
+const cleanUp = (parentId) => new Promise((resolve, reject) => {
+
+    // possible that component was removed before first ad was created
+    if (!window.ramp.settings || !window.ramp.settings.slots)
+        return;
+
+    delete window.ramp.forcePath;
+
+    let slotsToRemove = [];
+    Object.entries(window.ramp.settings.slots).forEach(([slotName, slot]) => {
+        if (
+            oopUnits.includes(slot.type)
+            || slot.videoType === 'Bolt Player'
+        ) {
+            slotsToRemove.push(slotName);
+        }
+    });
+
+    if (slotsToRemove.length > 0) {
+        window.ramp.destroyUnits(slotsToRemove)
+        .finally(() => resolve());
+    }
+});
+
+
 export default class Ramp extends React.Component {
     constructor(props) {
 
@@ -25,22 +51,31 @@ export default class Ramp extends React.Component {
             console.error('publisherId and id are required props.');
             return;
         }
-        this.init(props.publisherId, props.id);
+        this.init(props);
 
     }
 
-    init (publisherId, id) {
+    init ({publisherId, id, forcePath}) {
 
-        if (window._pwRampComponentLoaded)
-            return;
+        if (forcePath)
+            window.ramp.forcePath = forcePath;
 
-        window._pwRampComponentLoaded = true;
-        window.ramp.config = `https://config.playwire.com/${publisherId}/v2/websites/${id}/banner.json`;
-        const configScript = document.createElement("script");
-        // configScript.src = `https://cdn.intergient.com/${publisherId}/${id}/ramp.js`;
-        configScript.src = 'https://cdn.intergient.com/ramp_core.js';
-        document.head.appendChild(configScript);
+        // make sure we only do this once per "app" load
+        if (!window._pwRampComponentLoaded) {
+            window._pwRampComponentLoaded = true;
 
+            window.ramp.config = `https://config.playwire.com/${publisherId}/v2/websites/${id}/banner.json`;
+            const configScript = document.createElement("script");
+            // configScript.src = `https://cdn.intergient.com/${publisherId}/${id}/ramp.js`;
+            configScript.src = 'https://cdn.intergient.com/ramp_core.js';
+            document.head.appendChild(configScript);
+        }
+
+        this.displayTaglessUnits();
+
+    }
+
+    displayTaglessUnits () {
         window.ramp.que.push(() => {
             window.ramp.addUnits([
                 {type: 'trendi_slideshow'},
@@ -58,11 +93,34 @@ export default class Ramp extends React.Component {
                 // {type: 'inimg'},
                 // {type: 'skin'}
             ])
-            .then(() => {
-                window.ramp.displayUnits();
+            .finally(() => {
+                return window.ramp.displayUnits();
+            })
+            .finally(() => {
+                console.log('done')
             });
         });
+    }
 
+    componentDidUpdate (prevProps) {
+        if (this.props.forcePath && prevProps.forcePath !== this.props.forcePath) {
+            window.ramp.forcePath = this.props.forcePath;
+            window.ramp.que.push(() => {
+                window.ramp.setPath(this.props.forcePath)
+                    .then(() => {
+                        return cleanUp();
+                    })
+                    .then(() => {
+                        this.displayTaglessUnits();
+                    });
+            });
+        }
+    }
+
+    componentWillUnmount () {
+        window.ramp.que.push(() => {
+            cleanUp(this.unitToAdd.selectorId);
+        });
     }
 
     render() {

--- a/src/lib/components/RampUnit.js
+++ b/src/lib/components/RampUnit.js
@@ -61,7 +61,7 @@ const cleanUp = (parentId) => {
     }
 };
 
-export default class Ramp extends React.Component {
+export default class RampUnit extends React.Component {
     constructor (props) {
         super (props);
         this.rendered = false;

--- a/src/lib/components/RampUnit.js
+++ b/src/lib/components/RampUnit.js
@@ -42,7 +42,7 @@ const getInitialUnit = (props) => {
 const cleanUp = (parentId) => {
 
     // possible that component was removed before first ad was created
-    if (!window.ramp.setttings || !window.ramp.settings.slots)
+    if (!window.ramp.settings || !window.ramp.settings.slots)
         return;
 
     let slotToRemove = null;


### PR DESCRIPTION
allow an optional `forcePath` prop to be passed. When the prop changes, destroy tagless units, and reload them based on the new path. Also, if/when the component unmounts, remove these tagless units.